### PR TITLE
이메일 인증에 캐시 적용

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,17 +1,11 @@
-import { Controller, Get, Inject } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
 import { ApiOperation } from '@nestjs/swagger';
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { Cache } from 'cache-manager'
 import { Public } from './auth/decorators/public.decorator';
 
 @Controller()
 export class AppController {
-  constructor(
-    private readonly appService: AppService,
-    @Inject(CACHE_MANAGER)
-    private cacheManager : Cache
-  ) {}
+  constructor(private readonly appService: AppService) {}
 
   @ApiOperation({ summary: 'getHello' })
   @Get()
@@ -19,23 +13,22 @@ export class AppController {
     return this.appService.getHello();
   }
 
-  @Public()
-  @ApiOperation({ summary: 'cache-test'})
-  @Get('/cache')
-  async getCache() : Promise<string>{
-    const savedTime = await this.cacheManager.get('time');
-    const test = await this.cacheManager.get('test');
-    console.log(test);
-    
-    if(savedTime){
-      console.log('cache!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
-      return "saved time : " + savedTime;
-    }
+  // @Public()
+  // @ApiOperation({ summary: 'cache-test'})
+  // @Get('/cache')
+  // async getCache() : Promise<string>{
+  //   const savedTime = await this.cacheManager.get('time');
+  //   const test = await this.cacheManager.get('test');
+  //   console.log(test);
 
-    const now = new Date().getTime();
+  //   if(savedTime){
+  //     console.log('cache!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
+  //     return "saved time : " + savedTime;
+  //   }
 
-   
-    await this.cacheManager.set('time',now); //ttl은 ms 단위
-    return "save new time : "+now;
-  }
+  //   const now = new Date().getTime();
+
+  //   await this.cacheManager.set('time',now); //ttl은 ms 단위
+  //   return "save new time : "+now;
+  // }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -41,10 +41,8 @@ import { RandomSubjectEntity } from './entities/randomSubject.entity';
 import { QnaEntity } from './entities/qna/qna.entity';
 import { QnaCommentEntity } from './entities/qna/qnacomment.entity';
 import { EbookImgEntity } from './entities/ebookImg.entity';
-import { CacheModule } from '@nestjs/cache-manager';
-import { RedisClientOptions } from 'redis';
-import { redisStore } from 'cache-manager-redis-store';
 import { EbookHistoryEntity } from './entities/ebookHistory.entity';
+import { RedisModule } from './redis/redis.module';
 
 @Module({
   imports: [
@@ -132,14 +130,14 @@ import { EbookHistoryEntity } from './entities/ebookHistory.entity';
     //   inGlobla:true,
     // }),
 
-    CacheModule.register({
-      Store: redisStore,
-      host: 'localhost',
-      port: 6379,
-      ttl: 6000, //seconds (ms)
-      max: 15, // maximum number of items in cache
-      inGlobla: true,
-    }),
+    // CacheModule.register({
+    //   Store: redisStore,
+    //   host: 'localhost',
+    //   port: 6379,
+    //   ttl: 6000, //seconds (ms)
+    //   max: 15, // maximum number of items in cache
+    //   inGlobla: true,
+    // }),
 
     BoardModule,
     UserModule,
@@ -149,6 +147,7 @@ import { EbookHistoryEntity } from './entities/ebookHistory.entity';
     SmallTalkModule,
     AdminModule,
     QnaModule,
+    RedisModule,
   ],
 
   controllers: [AppController],

--- a/src/entities/emailCheckCode.entity.ts
+++ b/src/entities/emailCheckCode.entity.ts
@@ -9,8 +9,5 @@ export class EmailCheckCodeEntity {
   email: string;
 
   @Column()
-  code: string;
-
-  @Column()
   check: boolean;
 }

--- a/src/redis/redis.module.ts
+++ b/src/redis/redis.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { RedisService } from './redis.service';
+import { CacheModule } from '@nestjs/cache-manager';
+import { redisStore } from 'cache-manager-redis-store';
+
+@Module({
+  imports: [
+    CacheModule.register({
+      Store: redisStore,
+      host: 'localhost',
+      port: 6379,
+      ttl: 60000, // ms
+      max: 15, // maximum number of items in cache
+      inGlobla: true,
+    }),
+  ],
+  providers: [RedisService],
+  exports: [RedisService],
+})
+export class RedisModule {}

--- a/src/redis/redis.service.spec.ts
+++ b/src/redis/redis.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RedisService } from './redis.service';
+
+describe('RedisService', () => {
+  let service: RedisService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RedisService],
+    }).compile();
+
+    service = module.get<RedisService>(RedisService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/redis/redis.service.ts
+++ b/src/redis/redis.service.ts
@@ -1,0 +1,24 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager/dist/caching';
+
+@Injectable()
+export class RedisService {
+  constructor(@Inject(CACHE_MANAGER) private readonly cache: Cache) {}
+
+  async get(key: string): Promise<any> {
+    return await this.cache.get(key);
+  }
+
+  async set(key: string, value: any, option?: any) {
+    await this.cache.set(key, value, option);
+  }
+
+  async reset() {
+    await this.cache.reset();
+  }
+
+  async del(key: string) {
+    await this.cache.del(key);
+  }
+}

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -12,6 +12,7 @@ import { UserImgEntity } from 'src/entities/userImg.entity';
 import { GetS3Url } from 'src/utils/GetS3Url';
 import { BoardModule } from 'src/board/board.module';
 import { EbookModule } from 'src/ebook/ebook.module';
+import { RedisModule } from 'src/redis/redis.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { EbookModule } from 'src/ebook/ebook.module';
       signOptions: { expiresIn: '1d' },
     }),
     TypeOrmModule.forFeature([UserEntity, EmailCheckCodeEntity, UserImgEntity]),
+    RedisModule,
   ],
   controllers: [UserController],
   providers: [UserService, GetToken, GetS3Url],


### PR DESCRIPTION
기존
DB에 코드 저장
DB에서 코드 불러와서 비교 후 인증

캐시 적용 후
key: email, value: code로 캐시에 저장
캐시 값과 비교 후 인증하면 할당했던 캐시 삭제

## 상세
redis 모듈을 분리하여 적용했습니다.